### PR TITLE
ASN.1 -> DER / PEM 파이프라인 크레이트 구현

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ entlib-native-hkdf =              { path = "crypto/hkdf",              version =
 entlib-native-hmac =              { path = "crypto/hmac",              version = "2.0.0" }
 entlib-native-sha2 =              { path = "crypto/sha2",              version = "2.0.0" }
 entlib-native-sha3 =              { path = "crypto/sha3",              version = "2.0.0" }
+entlib-native-armor =             { path = "crypto/armor",             version = "2.0.0" }
 entlib-native-mldsa =             { path = "crypto/mldsa",             version = "2.0.0" }
 entlib-native-pbkdf2 =            { path = "crypto/pbkdf2",            version = "2.0.0" }
 entlib-native-chacha20 =          { path = "crypto/chacha20",          version = "2.0.0" }

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Python이나 JPMS(Java Platform Module System)와 일관된 모듈 관리, 캡�
   - [ ] RSA(2048, 4096, 8192)
   - [ ] ED25519, ED448 서명
   - [ ] X25519, X448 키 합의
-- De/Serializer, En/Decoder
-  - [ ] ASN.1 인/디코더
-  - [ ] PEM/DER 직렬화기
+- Serializer / Encode Pipeline
+  - [X] DER
+  - [ ] PEM
 - PKC Standard Pipeline
   - [ ] PKCS #8
   - [PKCS #11](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html)

--- a/README_EN.md
+++ b/README_EN.md
@@ -54,9 +54,9 @@ We need to implement a variety of supported classic cryptographic algorithm modu
   - [ ] RSA (2048, 4096, 8192)
   - [ ] ED25519, ED448 Signatures
   - [ ] X25519, X448 Key Agreement
-- De/Serializer, En/Decoder
-  - [ ] ASN.1 Encoder/Decoder
-  - [ ] PEM/DER Serializer
+- Serializer / Encode Pipeline
+  - [X] DER
+  - [ ] PEM
 - PKC Standard Pipeline
   - [ ] PKCS #8
   - [PKCS #11](https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html)

--- a/crypto/armor/src/asn1/error.rs
+++ b/crypto/armor/src/asn1/error.rs
@@ -1,0 +1,12 @@
+//! ASN.1 오류 타입 모듈입니다.
+
+/// ASN.1 관련 연산 중 발생하는 오류 열거형입니다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ASN1Error {
+    /// 입력 버퍼가 예상보다 짧음
+    UnexpectedEof,
+    /// 유효하지 않은 OID 인코딩 또는 구조
+    InvalidOid,
+    /// 길이 계산 시 산술 오버플로우
+    LengthOverflow,
+}

--- a/crypto/armor/src/asn1/mod.rs
+++ b/crypto/armor/src/asn1/mod.rs
@@ -1,0 +1,8 @@
+mod error;
+mod oid;
+mod tag;
+
+pub use error::ASN1Error;
+pub use oid::{OID_MAX_ARCS, Oid};
+pub(crate) use oid::{decode_oid, encode_base128};
+pub use tag::{Tag, TagClass};

--- a/crypto/armor/src/asn1/oid.rs
+++ b/crypto/armor/src/asn1/oid.rs
@@ -1,0 +1,203 @@
+//! ASN.1 OID(Object Identifier) 타입 모듈입니다.
+//! OID 비교는 알고리즘 식별자 누출을 막기 위해 상수-시간으로 수행합니다.
+
+use entlib_native_constant_time::traits::ConstantTimeEq;
+
+use crate::asn1::error::ASN1Error;
+use crate::error::ArmorError;
+use crate::error::ArmorError::ASN1;
+
+/// OID 최대 아크(arc) 수
+pub const OID_MAX_ARCS: usize = 16;
+
+/// ASN.1 OID를 나타내는 구조체입니다.
+/// 내부 아크 배열은 항상 `OID_MAX_ARCS` 크기로 고정되어 있으며,
+/// `len` 이후의 슬롯은 0으로 패딩되어 상수-시간 비교를 보장합니다.
+#[derive(Clone, Copy, Debug)]
+pub struct Oid {
+    arcs: [u32; OID_MAX_ARCS],
+    len: usize,
+}
+
+impl Oid {
+    /// 아크 슬라이스로 OID를 생성하는 함수입니다.
+    ///
+    /// # Arguments
+    /// `arcs` — OID 아크 배열. 첫 번째 아크는 0, 1, 2 중 하나여야 합니다.
+    ///
+    /// # Errors
+    /// 아크 수가 2 미만이거나 `OID_MAX_ARCS` 초과, 또는 첫 아크 > 2이면 `InvalidOid`.
+    pub fn from_arcs(arcs: &[u32]) -> Result<Self, ArmorError> {
+        if arcs.len() < 2 || arcs.len() > OID_MAX_ARCS {
+            return Err(ASN1(ASN1Error::InvalidOid));
+        }
+        if arcs[0] > 2 {
+            return Err(ASN1(ASN1Error::InvalidOid));
+        }
+        // 첫 아크가 0 또는 1이면 두 번째 아크는 반드시 0–39
+        if arcs[0] < 2 && arcs[1] > 39 {
+            return Err(ASN1(ASN1Error::InvalidOid));
+        }
+        // 첫 두 아크의 결합 값(40*a0+a1)이 u32에 맞는지 확인
+        let combined = (arcs[0] as u64)
+            .checked_mul(40)
+            .and_then(|v| v.checked_add(arcs[1] as u64))
+            .ok_or(ASN1(ASN1Error::InvalidOid))?;
+        if combined > u32::MAX as u64 {
+            return Err(ASN1(ASN1Error::InvalidOid));
+        }
+
+        let mut result = Oid {
+            arcs: [0u32; OID_MAX_ARCS],
+            len: arcs.len(),
+        };
+        result.arcs[..arcs.len()].copy_from_slice(arcs);
+        Ok(result)
+    }
+
+    /// OID 아크 슬라이스를 반환합니다.
+    #[inline(always)]
+    pub fn arcs(&self) -> &[u32] {
+        &self.arcs[..self.len]
+    }
+
+    /// 아크 수를 반환합니다.
+    #[inline(always)]
+    pub fn arc_count(&self) -> usize {
+        self.len
+    }
+
+    /// 두 OID를 상수-시간으로 비교하는 함수입니다.
+    ///
+    /// # Security Note
+    /// 알고리즘 식별자 비교 시 타이밍 부채널 공격을 방지하기 위해
+    /// 모든 `OID_MAX_ARCS` 슬롯을 항상 비교합니다.
+    pub fn ct_eq(&self, other: &Oid) -> bool {
+        // 길이 비교 (상수-시간)
+        let len_eq = self.len.ct_eq(&other.len).unwrap_u8();
+
+        // 아크 배열 전체 비교 — len 이후는 0 패딩이므로 항상 동일
+        let mut acc = 0xFFu8;
+        for i in 0..OID_MAX_ARCS {
+            acc &= self.arcs[i].ct_eq(&other.arcs[i]).unwrap_u8();
+        }
+
+        (acc & len_eq) == 0xFF
+    }
+
+    /// DER 인코딩 시 값 바이트 길이를 반환하는 함수입니다.
+    #[allow(dead_code)]
+    pub(crate) fn der_value_len(&self) -> Result<usize, ArmorError> {
+        let first = (self.arcs[0] as u64)
+            .checked_mul(40)
+            .and_then(|v| v.checked_add(self.arcs[1] as u64))
+            .ok_or(ASN1(ASN1Error::InvalidOid))? as u32;
+
+        let mut total = base128_encoded_len(first);
+        for i in 2..self.len {
+            total = total
+                .checked_add(base128_encoded_len(self.arcs[i]))
+                .ok_or(ASN1(ASN1Error::LengthOverflow))?;
+        }
+        Ok(total)
+    }
+}
+
+/// base-128 VarInt 인코딩 바이트 수를 반환하는 함수입니다.
+#[allow(dead_code)]
+pub(crate) fn base128_encoded_len(val: u32) -> usize {
+    match val {
+        0x0000_0000..=0x0000_007F => 1,
+        0x0000_0080..=0x0000_3FFF => 2,
+        0x0000_4000..=0x001F_FFFF => 3,
+        0x0020_0000..=0x0FFF_FFFF => 4,
+        _ => 5,
+    }
+}
+
+/// base-128 VarInt를 `buf`에 인코딩하는 함수입니다.
+pub(crate) fn encode_base128(buf: &mut alloc::vec::Vec<u8>, val: u32) {
+    if val == 0 {
+        buf.push(0x00);
+        return;
+    }
+    let mut tmp = [0u8; 5];
+    let mut count = 0usize;
+    let mut v = val;
+    while v > 0 {
+        tmp[count] = (v & 0x7F) as u8;
+        v >>= 7;
+        count += 1;
+    }
+    // 최상위 그룹부터 내림차순으로 기록 (모든 바이트 except last에 0x80 세트)
+    for i in (0..count).rev() {
+        let continuation = if i > 0 { 0x80u8 } else { 0x00u8 };
+        buf.push(tmp[i] | continuation);
+    }
+}
+
+/// `buf[pos..end]`에서 base-128 VarInt를 디코딩하는 함수입니다.
+///
+/// # Security Note
+/// 5바이트 초과 시 오류, u32 범위 초과 시 오류 (버퍼 오버리드 방지).
+pub(crate) fn decode_base128(buf: &[u8], pos: &mut usize, end: usize) -> Result<u32, ArmorError> {
+    let mut val: u64 = 0;
+    let mut count = 0usize;
+    loop {
+        if *pos >= end {
+            return Err(ASN1(ASN1Error::UnexpectedEof));
+        }
+        if count >= 5 {
+            return Err(ASN1(ASN1Error::InvalidOid));
+        }
+        let byte = buf[*pos];
+        *pos += 1;
+        count += 1;
+        val = (val << 7) | (byte & 0x7F) as u64;
+        if val > u32::MAX as u64 {
+            return Err(ASN1(ASN1Error::InvalidOid));
+        }
+        if byte & 0x80 == 0 {
+            return Ok(val as u32);
+        }
+    }
+}
+
+/// DER OID 값 바이트로부터 `Oid`를 파싱하는 함수입니다.
+pub(crate) fn decode_oid(bytes: &[u8]) -> Result<Oid, ArmorError> {
+    if bytes.is_empty() {
+        return Err(ASN1(ASN1Error::InvalidOid));
+    }
+
+    let mut arcs = [0u32; OID_MAX_ARCS];
+    let mut arc_count = 0usize;
+    let mut pos = 0usize;
+
+    // 첫 번째 하위식별자: 40*a0 + a1
+    let first_sub = decode_base128(bytes, &mut pos, bytes.len())?;
+    let (a0, a1) = if first_sub < 40 {
+        (0u32, first_sub)
+    } else if first_sub < 80 {
+        (1u32, first_sub - 40)
+    } else {
+        (2u32, first_sub.wrapping_sub(80))
+    };
+    arcs[arc_count] = a0;
+    arc_count += 1;
+    arcs[arc_count] = a1;
+    arc_count += 1;
+
+    // 나머지 하위식별자
+    while pos < bytes.len() {
+        if arc_count >= OID_MAX_ARCS {
+            return Err(ASN1(ASN1Error::InvalidOid));
+        }
+        arcs[arc_count] = decode_base128(bytes, &mut pos, bytes.len())?;
+        arc_count += 1;
+    }
+
+    Ok(Oid {
+        arcs,
+        len: arc_count,
+    })
+}

--- a/crypto/armor/src/asn1/tag.rs
+++ b/crypto/armor/src/asn1/tag.rs
@@ -1,0 +1,65 @@
+/// ASN.1 태그 클래스입니다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TagClass {
+    Universal = 0x00,
+    Application = 0x40,
+    Context = 0x80,
+    Private = 0xC0,
+}
+
+/// DER 태그 바이트를 감싸는 구조체입니다.
+/// 단순 u8 래퍼로, 비트 필드(클래스·구성·번호)를 직접 해석합니다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Tag(pub u8);
+
+impl Tag {
+    pub const BOOLEAN: Tag = Tag(0x01);
+    pub const INTEGER: Tag = Tag(0x02);
+    pub const BIT_STRING: Tag = Tag(0x03);
+    pub const OCTET_STRING: Tag = Tag(0x04);
+    pub const NULL: Tag = Tag(0x05);
+    pub const OID: Tag = Tag(0x06);
+    pub const UTF8_STRING: Tag = Tag(0x0C);
+    pub const PRINTABLE_STRING: Tag = Tag(0x13);
+    pub const IA5_STRING: Tag = Tag(0x16);
+    pub const UTC_TIME: Tag = Tag(0x17);
+    pub const GENERALIZED_TIME: Tag = Tag(0x18);
+    /// SEQUENCE OF / SEQUENCE (구성형 0x30)
+    pub const SEQUENCE: Tag = Tag(0x30);
+    /// SET OF / SET (구성형 0x31)
+    pub const SET: Tag = Tag(0x31);
+
+    /// 태그 클래스를 반환합니다.
+    #[inline(always)]
+    pub fn class(self) -> TagClass {
+        match self.0 & 0xC0 {
+            0x00 => TagClass::Universal,
+            0x40 => TagClass::Application,
+            0x80 => TagClass::Context,
+            _ => TagClass::Private,
+        }
+    }
+
+    /// 태그가 구성형(Constructed)이면 true를 반환합니다.
+    #[inline(always)]
+    pub fn is_constructed(self) -> bool {
+        self.0 & 0x20 != 0
+    }
+
+    /// 태그 번호(하위 5비트)를 반환합니다.
+    #[inline(always)]
+    pub fn number(self) -> u8 {
+        self.0 & 0x1F
+    }
+
+    /// 컨텍스트 태그를 생성합니다.
+    ///
+    /// # Arguments
+    /// - `num` — 태그 번호 (0-30)
+    /// - `constructed` — 구성형 여부
+    #[inline(always)]
+    pub fn context(num: u8, constructed: bool) -> Tag {
+        Tag(0x80 | (if constructed { 0x20 } else { 0x00 }) | (num & 0x1F))
+    }
+}

--- a/crypto/armor/src/der/error.rs
+++ b/crypto/armor/src/der/error.rs
@@ -1,0 +1,36 @@
+//! DER 파싱·인코딩 오류 타입 모듈입니다.
+
+/// DER 파싱 및 인코딩 중 발생하는 오류 열거형입니다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DerError {
+    /// 입력 버퍼가 예상보다 짧음
+    UnexpectedEof,
+    /// 유효하지 않은 태그 바이트 (EOC, 장형식 태그 등)
+    InvalidTag,
+    /// 유효하지 않은 길이 인코딩
+    InvalidLength,
+    /// 부정길이(Indefinite-Length) 형식 거부 — BER 전용
+    IndefiniteLength,
+    /// 비최소 길이 인코딩 (DER 위반)
+    NonMinimalLength,
+    /// 비최소 INTEGER 인코딩 (불필요한 선행 0x00/0xFF 바이트)
+    NonMinimalInteger,
+    /// BOOLEAN 값이 0x00 또는 0xFF가 아님 (DER 위반)
+    InvalidBooleanEncoding,
+    /// BIT STRING의 미사용 비트 수가 0-7 범위를 벗어남
+    InvalidBitString,
+    /// 유효하지 않은 OID 인코딩 또는 구조
+    InvalidOid,
+    /// 예상한 태그와 실제 태그가 불일치
+    UnexpectedTag { expected: u8, got: u8 },
+    /// 길이 계산 시 산술 오버플로우
+    LengthOverflow,
+    /// 최대 중첩 깊이 초과 — 재귀 폭탄 방지
+    MaxDepthExceeded,
+    /// 파싱 완료 후 잔여 바이트 존재
+    TrailingData,
+    /// 빈 입력
+    EmptyInput,
+    /// SecureBuffer 할당 실패
+    AllocationError,
+}

--- a/crypto/armor/src/der/length.rs
+++ b/crypto/armor/src/der/length.rs
@@ -1,0 +1,112 @@
+//! DER 길이 인코딩/디코딩 모듈입니다.
+//! 부정길이(BER) 거부, 비최소 인코딩 거부, 오버플로우 방어를 포함합니다.
+
+use alloc::vec::Vec;
+
+use crate::der::error::DerError;
+use crate::error::ArmorError;
+use crate::error::ArmorError::DER;
+
+/// 단일 TLV 값의 최대 허용 바이트 수 (16 MiB − 1)
+pub(crate) const MAX_VALUE_LEN: usize = 0x00FF_FFFF;
+
+/// `buf[pos]`에서 DER 길이를 디코딩하여 `(length, consumed_bytes)`를 반환하는 함수입니다.
+///
+/// # Security Note
+/// - 부정길이(0x80) 즉시 거부
+/// - 예약 바이트(0xFF) 거부
+/// - 비최소 인코딩 (long-form으로 표현 가능한 길이를 short-form으로 표현하거나,
+///   long-form 바이트에 선행 0x00) 거부
+/// - 길이 계산 오버플로우: `checked_mul` + `checked_add`로 방어
+pub(crate) fn decode_length(buf: &[u8], pos: usize) -> Result<(usize, usize), ArmorError> {
+    if pos >= buf.len() {
+        return Err(DER(DerError::UnexpectedEof));
+    }
+    let first = buf[pos];
+
+    // 부정길이 (BER 전용)
+    if first == 0x80 {
+        return Err(DER(DerError::IndefiniteLength));
+    }
+    // 예약 바이트
+    if first == 0xFF {
+        return Err(DER(DerError::InvalidLength));
+    }
+
+    // 단형식 (short form): 0x00–0x7F
+    if first & 0x80 == 0 {
+        return Ok((first as usize, 1));
+    }
+
+    // 장형식 (long form): 0x81–0x84
+    let num_len_bytes = (first & 0x7F) as usize;
+    // 지원 범위 초과 또는 num_len_bytes == 0 (부정길이로 이미 처리됨)
+    if num_len_bytes == 0 || num_len_bytes > 4 {
+        return Err(DER(DerError::InvalidLength));
+    }
+
+    let end = pos
+        .checked_add(1)
+        .and_then(|p| p.checked_add(num_len_bytes))
+        .ok_or(DER(DerError::LengthOverflow))?;
+    if end > buf.len() {
+        return Err(DER(DerError::UnexpectedEof));
+    }
+
+    // 선행 0x00 금지 (비최소 인코딩)
+    if buf[pos + 1] == 0x00 {
+        return Err(DER(DerError::NonMinimalLength));
+    }
+
+    let mut length: usize = 0;
+    for i in 0..num_len_bytes {
+        length = length
+            .checked_mul(256)
+            .ok_or(DER(DerError::LengthOverflow))?
+            .checked_add(buf[pos + 1 + i] as usize)
+            .ok_or(DER(DerError::LengthOverflow))?;
+    }
+
+    // DER: 길이 < 128이면 반드시 단형식으로 인코딩해야 함
+    if length < 128 {
+        return Err(DER(DerError::NonMinimalLength));
+    }
+
+    if length > MAX_VALUE_LEN {
+        return Err(DER(DerError::LengthOverflow));
+    }
+
+    Ok((length, 1 + num_len_bytes))
+}
+
+/// DER 길이를 `buf`에 인코딩하는 함수입니다.
+///
+/// # Security Note
+/// 항상 최소 바이트로 인코딩합니다 (DER 요구사항).
+pub(crate) fn encode_length(buf: &mut Vec<u8>, length: usize) -> Result<(), ArmorError> {
+    if length > MAX_VALUE_LEN {
+        return Err(DER(DerError::LengthOverflow));
+    }
+    if length < 128 {
+        buf.push(length as u8);
+    } else if length <= 0xFF {
+        buf.push(0x81);
+        buf.push(length as u8);
+    } else if length <= 0xFFFF {
+        buf.push(0x82);
+        buf.push((length >> 8) as u8);
+        buf.push(length as u8);
+    } else if length <= 0xFF_FFFF {
+        buf.push(0x83);
+        buf.push((length >> 16) as u8);
+        buf.push((length >> 8) as u8);
+        buf.push(length as u8);
+    } else {
+        buf.push(0x84);
+        buf.push((length >> 24) as u8);
+        buf.push((length >> 16) as u8);
+        buf.push((length >> 8) as u8);
+        buf.push(length as u8);
+    }
+    Ok(())
+}

--- a/crypto/armor/src/der/mod.rs
+++ b/crypto/armor/src/der/mod.rs
@@ -1,0 +1,12 @@
+mod error;
+mod length;
+mod reader;
+mod writer;
+
+pub use error::DerError;
+pub use reader::{DerReader, DerTlv};
+pub use writer::DerWriter;
+
+/// 최대 허용 중첩 깊이
+/// 재귀 폭탄 방어
+pub const MAX_DEPTH: u8 = 16;

--- a/crypto/armor/src/der/reader.rs
+++ b/crypto/armor/src/der/reader.rs
@@ -1,0 +1,371 @@
+//! DER 파서(리더) 모듈입니다.
+//! 재귀 없이 커서 기반으로 TLV를 순회하며 깊이 제한으로 중첩 폭탄을 방어합니다.
+
+use crate::asn1::Oid;
+use crate::asn1::Tag;
+use crate::der::error::DerError;
+use crate::der::length;
+use crate::error::ArmorError;
+use crate::error::ArmorError::DER;
+use entlib_native_secure_buffer::SecureBuffer;
+
+/// 단일 TLV(Tag-Length-Value) 파싱 결과입니다.
+#[derive(Debug)]
+pub struct DerTlv<'a> {
+    /// 파싱된 태그
+    pub tag: Tag,
+    /// 값 바이트 슬라이스 (복사 없이 원본 버퍼 참조)
+    pub value: &'a [u8],
+}
+
+/// 커서 기반 DER 파서 구조체입니다.
+#[derive(Debug)]
+///
+/// # Security Note
+/// - 스택 재귀 없이 반복(iterative) 방식으로 동작합니다.
+/// - `read_sequence` 등 중첩 진입 시 `depth`를 감소시켜 최대 `MAX_DEPTH` 레벨로 제한합니다.
+/// - 모든 길이 계산은 `checked_add`를 사용하여 오버플로우를 방어합니다.
+pub struct DerReader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> DerReader<'a> {
+    /// 입력 슬라이스로 DerReader를 생성하는 함수입니다.
+    ///
+    /// # Errors
+    /// 빈 입력이면 `EmptyInput`.
+    pub fn new(data: &'a [u8]) -> Result<Self, ArmorError> {
+        if data.is_empty() {
+            return Err(DER(DerError::EmptyInput));
+        }
+        Ok(Self { buf: data, pos: 0 })
+    }
+
+    pub(crate) fn from_slice(data: &'a [u8]) -> Self {
+        Self { buf: data, pos: 0 }
+    }
+
+    /// 남은 바이트가 없으면 true를 반환합니다.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.pos >= self.buf.len()
+    }
+
+    /// 남은 바이트 수를 반환합니다.
+    #[inline(always)]
+    pub fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    /// 다음 태그를 소비하지 않고 미리 읽는 함수입니다.
+    ///
+    /// # Errors
+    /// EOF, 장형식 태그, EOC 태그 시 오류.
+    pub fn peek_tag(&self) -> Result<Tag, ArmorError> {
+        if self.pos >= self.buf.len() {
+            return Err(DER(DerError::UnexpectedEof));
+        }
+        let byte = self.buf[self.pos];
+        validate_tag_byte(byte)?;
+        Ok(Tag(byte))
+    }
+
+    /// 다음 TLV 하나를 파싱하는 함수입니다.
+    ///
+    /// # Security Note
+    /// 값 범위 검증(`pos + length <= buf.len()`)을 통해 버퍼 오버리드를 방어합니다.
+    pub fn read_tlv(&mut self) -> Result<DerTlv<'a>, ArmorError> {
+        let (tag, length) = self.read_tag_and_length()?;
+        let value = self.take_value_slice(length)?;
+        Ok(DerTlv { tag, value })
+    }
+
+    /// SEQUENCE를 읽어 내부 컨텐츠에 대한 새 DerReader를 반환하는 함수입니다.
+    ///
+    /// # Arguments
+    /// `depth` — 남은 허용 중첩 깊이. 진입 시 1 감소.
+    ///
+    /// # Errors
+    /// `depth == 0`이면 `MaxDepthExceeded`.
+    pub fn read_sequence(&mut self, depth: &mut u8) -> Result<DerReader<'a>, ArmorError> {
+        self.read_constructed(Tag::SEQUENCE, depth)
+    }
+
+    /// SET을 읽어 내부 컨텐츠에 대한 새 DerReader를 반환하는 함수입니다.
+    pub fn read_set(&mut self, depth: &mut u8) -> Result<DerReader<'a>, ArmorError> {
+        self.read_constructed(Tag::SET, depth)
+    }
+
+    /// EXPLICIT 컨텍스트 태그 `[tag_num]`를 읽어 내부 DerReader를 반환하는 함수입니다.
+    ///
+    /// # Arguments
+    /// - `tag_num` — 컨텍스트 태그 번호 (0-30)
+    /// - `depth` — 남은 허용 중첩 깊이
+    pub fn read_explicit_tag(
+        &mut self,
+        tag_num: u8,
+        depth: &mut u8,
+    ) -> Result<DerReader<'a>, ArmorError> {
+        let expected = Tag::context(tag_num, true);
+        self.read_constructed(expected, depth)
+    }
+
+    /// IMPLICIT 컨텍스트 태그 `[tag_num]`의 값 바이트를 반환하는 함수입니다.
+    ///
+    /// IMPLICIT 태그는 원래 타입의 태그가 `[tag_num]`로 교체된 것이므로
+    /// 값 바이트는 원래 타입의 내용과 동일합니다.
+    pub fn read_implicit_value(&mut self, tag_num: u8) -> Result<&'a [u8], ArmorError> {
+        let expected = Tag::context(tag_num, false);
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != expected {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: expected.0,
+                got: tag.0,
+            }));
+        }
+        self.take_value_slice(length)
+    }
+
+    /// INTEGER 값 바이트를 반환하는 함수입니다.
+    ///
+    /// # Security Note
+    /// 비최소 인코딩(불필요한 선행 0x00 또는 0xFF)을 거부합니다.
+    /// 반환 슬라이스에는 부호 바이트(선행 0x00)가 포함될 수 있습니다.
+    pub fn read_integer_bytes(&mut self) -> Result<&'a [u8], ArmorError> {
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != Tag::INTEGER {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: Tag::INTEGER.0,
+                got: tag.0,
+            }));
+        }
+        let value = self.take_value_slice(length)?;
+        validate_integer_encoding(value)?;
+        Ok(value)
+    }
+
+    /// INTEGER 값을 SecureBuffer로 복사하여 반환하는 함수입니다.
+    ///
+    /// # Security Note
+    /// 비밀 키 파싱 등 민감 데이터에 사용합니다.
+    /// 메모리 잠금된 버퍼로 복사하여 스왑 유출을 방지합니다.
+    pub fn read_integer_secure(&mut self) -> Result<SecureBuffer, ArmorError> {
+        let bytes = self.read_integer_bytes()?;
+        copy_to_secure_buffer(bytes)
+    }
+
+    /// OCTET STRING 값 바이트를 반환하는 함수입니다.
+    pub fn read_octet_string(&mut self) -> Result<&'a [u8], ArmorError> {
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != Tag::OCTET_STRING {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: Tag::OCTET_STRING.0,
+                got: tag.0,
+            }));
+        }
+        self.take_value_slice(length)
+    }
+
+    /// OCTET STRING 값을 SecureBuffer로 복사하는 함수입니다.
+    ///
+    /// # Security Note
+    /// 암호화된 키 블롭 등 민감 데이터에 사용합니다.
+    pub fn read_octet_string_secure(&mut self) -> Result<SecureBuffer, ArmorError> {
+        let bytes = self.read_octet_string()?;
+        copy_to_secure_buffer(bytes)
+    }
+
+    /// BIT STRING을 파싱하여 `(데이터 슬라이스, 미사용 비트 수)`를 반환하는 함수입니다.
+    ///
+    /// # Security Note
+    /// 미사용 비트 수 바이트가 0–7 범위를 벗어나면 즉시 거부합니다.
+    /// 암호 키 파싱 시 미사용 비트는 항상 0이어야 합니다.
+    pub fn read_bit_string(&mut self) -> Result<(&'a [u8], u8), ArmorError> {
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != Tag::BIT_STRING {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: Tag::BIT_STRING.0,
+                got: tag.0,
+            }));
+        }
+        if length == 0 {
+            return Err(DER(DerError::InvalidBitString));
+        }
+        let raw = self.take_value_slice(length)?;
+        let unused_bits = raw[0];
+        if unused_bits > 7 {
+            return Err(DER(DerError::InvalidBitString));
+        }
+        // 미사용 비트가 있는 경우 데이터가 최소 1바이트 이상이어야 함
+        if unused_bits > 0 && length < 2 {
+            return Err(DER(DerError::InvalidBitString));
+        }
+        Ok((&raw[1..], unused_bits))
+    }
+
+    /// OID를 파싱하는 함수입니다.
+    pub fn read_oid(&mut self) -> Result<Oid, ArmorError> {
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != Tag::OID {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: Tag::OID.0,
+                got: tag.0,
+            }));
+        }
+        if length == 0 {
+            return Err(DER(DerError::InvalidOid));
+        }
+        let value = self.take_value_slice(length)?;
+        crate::asn1::decode_oid(value)
+    }
+
+    /// NULL을 파싱하는 함수입니다.
+    ///
+    /// # Errors
+    /// NULL의 길이가 0이 아니면 `InvalidLength`.
+    pub fn read_null(&mut self) -> Result<(), ArmorError> {
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != Tag::NULL {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: Tag::NULL.0,
+                got: tag.0,
+            }));
+        }
+        if length != 0 {
+            return Err(DER(DerError::InvalidLength));
+        }
+        Ok(())
+    }
+
+    /// BOOLEAN을 파싱하는 함수입니다.
+    ///
+    /// # Security Note
+    /// DER에서 BOOLEAN은 0x00(false) 또는 0xFF(true)만 허용합니다.
+    /// BER의 0x01..0xFE는 거부됩니다.
+    pub fn read_boolean(&mut self) -> Result<bool, ArmorError> {
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != Tag::BOOLEAN {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: Tag::BOOLEAN.0,
+                got: tag.0,
+            }));
+        }
+        if length != 1 {
+            return Err(DER(DerError::InvalidLength));
+        }
+        let value = self.take_value_slice(1)?;
+        match value[0] {
+            0x00 => Ok(false),
+            0xFF => Ok(true),
+            _ => Err(DER(DerError::InvalidBooleanEncoding)),
+        }
+    }
+
+    /// 파싱 완료 후 잔여 바이트가 없는지 확인하는 함수입니다.
+    ///
+    /// # Errors
+    /// 잔여 바이트가 있으면 `TrailingData`.
+    pub fn expect_empty(&self) -> Result<(), ArmorError> {
+        if self.is_empty() {
+            Ok(())
+        } else {
+            Err(DER(DerError::TrailingData))
+        }
+    }
+
+    //
+    // 내부 헬퍼
+    //
+
+    fn read_tag_and_length(&mut self) -> Result<(Tag, usize), ArmorError> {
+        if self.pos >= self.buf.len() {
+            return Err(DER(DerError::UnexpectedEof));
+        }
+        let tag_byte = self.buf[self.pos];
+        validate_tag_byte(tag_byte)?;
+        self.pos += 1;
+
+        let (length, consumed) = length::decode_length(self.buf, self.pos)?;
+        self.pos += consumed;
+        Ok((Tag(tag_byte), length))
+    }
+
+    fn take_value_slice(&mut self, length: usize) -> Result<&'a [u8], ArmorError> {
+        let end = self
+            .pos
+            .checked_add(length)
+            .ok_or(DER(DerError::LengthOverflow))?;
+        if end > self.buf.len() {
+            return Err(DER(DerError::UnexpectedEof));
+        }
+        let slice = &self.buf[self.pos..end];
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn read_constructed(
+        &mut self,
+        expected_tag: Tag,
+        depth: &mut u8,
+    ) -> Result<DerReader<'a>, ArmorError> {
+        if *depth == 0 {
+            return Err(DER(DerError::MaxDepthExceeded));
+        }
+        let (tag, length) = self.read_tag_and_length()?;
+        if tag != expected_tag {
+            return Err(DER(DerError::UnexpectedTag {
+                expected: expected_tag.0,
+                got: tag.0,
+            }));
+        }
+        let inner = self.take_value_slice(length)?;
+        *depth -= 1;
+        Ok(DerReader::from_slice(inner))
+    }
+}
+
+//
+// 파일-내부 헬퍼 함수
+//
+
+/// 태그 바이트 유효성 검사 함수입니다.
+///
+/// # Security Note
+/// - 장형식 태그(0x1F 마스크) 거부: 다중 바이트 태그 파싱 로직 제거로 공격 면 축소
+/// - EOC 태그(0x00) 거부: 부정길이 BER 구조에서만 사용
+fn validate_tag_byte(byte: u8) -> Result<(), ArmorError> {
+    if byte & 0x1F == 0x1F {
+        return Err(DER(DerError::InvalidTag));
+    }
+    if byte == 0x00 {
+        return Err(DER(DerError::InvalidTag));
+    }
+    Ok(())
+}
+
+/// INTEGER 인코딩의 최소성을 검증하는 함수입니다.
+fn validate_integer_encoding(bytes: &[u8]) -> Result<(), ArmorError> {
+    if bytes.is_empty() {
+        return Err(DER(DerError::NonMinimalInteger));
+    }
+    if bytes.len() > 1 {
+        // 불필요한 선행 0x00 (양수의 비최소 인코딩)
+        if bytes[0] == 0x00 && bytes[1] & 0x80 == 0 {
+            return Err(DER(DerError::NonMinimalInteger));
+        }
+        // 불필요한 선행 0xFF (음수의 비최소 인코딩)
+        if bytes[0] == 0xFF && bytes[1] & 0x80 != 0 {
+            return Err(DER(DerError::NonMinimalInteger));
+        }
+    }
+    Ok(())
+}
+
+/// 바이트 슬라이스를 SecureBuffer에 복사하는 함수입니다.
+fn copy_to_secure_buffer(bytes: &[u8]) -> Result<SecureBuffer, ArmorError> {
+    let mut buf =
+        SecureBuffer::new_owned(bytes.len()).map_err(|_| DER(DerError::AllocationError))?;
+    buf.as_mut_slice().copy_from_slice(bytes);
+    Ok(buf)
+}

--- a/crypto/armor/src/der/writer.rs
+++ b/crypto/armor/src/der/writer.rs
@@ -1,0 +1,194 @@
+//! DER 인코더(라이터) 모듈입니다.
+//! 항상 최소 바이트 DER 형식으로 인코딩합니다.
+
+use crate::asn1;
+use crate::asn1::Oid;
+use crate::asn1::Tag;
+use crate::der::error::DerError;
+use crate::der::length;
+use crate::error::ArmorError;
+use crate::error::ArmorError::DER;
+use alloc::vec::Vec;
+
+/// DER 인코더 구조체입니다.
+///
+/// 개별 write_* 메서드로 TLV를 누적하고 `finish()`로 최종 바이트열을 회수합니다.
+/// 중첩 SEQUENCE는 내부 컨텐츠를 별도 DerWriter로 인코딩한 뒤
+/// `write_sequence(inner.finish())` 형태로 조립합니다.
+pub struct DerWriter {
+    buf: Vec<u8>,
+}
+
+impl DerWriter {
+    /// 빈 DerWriter를 생성합니다.
+    pub fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    /// 누적된 인코딩 결과를 반환하는 함수입니다.
+    pub fn finish(self) -> Vec<u8> {
+        self.buf
+    }
+
+    /// SEQUENCE TLV를 인코딩하는 함수입니다.
+    pub fn write_sequence(&mut self, inner: &[u8]) -> Result<(), ArmorError> {
+        self.push_tlv(Tag::SEQUENCE.0, inner)
+    }
+
+    /// SET TLV를 인코딩하는 함수입니다.
+    pub fn write_set(&mut self, inner: &[u8]) -> Result<(), ArmorError> {
+        self.push_tlv(Tag::SET.0, inner)
+    }
+
+    /// EXPLICIT 컨텍스트 태그 `[tag_num]`를 인코딩하는 함수입니다.
+    pub fn write_explicit_tag(&mut self, tag_num: u8, inner: &[u8]) -> Result<(), ArmorError> {
+        let tag = Tag::context(tag_num, true);
+        self.push_tlv(tag.0, inner)
+    }
+
+    /// IMPLICIT 컨텍스트 태그 `[tag_num]`를 원시 값 바이트로 인코딩하는 함수입니다.
+    pub fn write_implicit_tag(&mut self, tag_num: u8, value: &[u8]) -> Result<(), ArmorError> {
+        let tag = Tag::context(tag_num, false);
+        self.push_tlv(tag.0, value)
+    }
+
+    /// 부호 없는 정수를 DER INTEGER로 인코딩하는 함수입니다.
+    ///
+    /// # Security Note
+    /// - 선행 0x00 바이트를 제거하여 최소 표현을 보장합니다.
+    /// - 최상위 비트가 1이면(음수로 오독될 수 있으므로) 0x00 부호 바이트를 자동 삽입합니다.
+    /// - 입력이 비어 있으면 정수 0으로 인코딩합니다.
+    pub fn write_integer_unsigned(&mut self, bytes: &[u8]) -> Result<(), ArmorError> {
+        let stripped = strip_leading_zeros(bytes);
+
+        if stripped.is_empty() {
+            // 값 0: INTEGER 0x00
+            return self.push_tlv(Tag::INTEGER.0, &[0x00]);
+        }
+
+        if stripped[0] & 0x80 != 0 {
+            // 최상위 비트가 1: 부호 바이트 0x00 삽입
+            let value_len = stripped
+                .len()
+                .checked_add(1)
+                .ok_or(DER(DerError::LengthOverflow))?;
+            self.buf.push(Tag::INTEGER.0);
+            length::encode_length(&mut self.buf, value_len)?;
+            self.buf.push(0x00);
+            self.buf.extend_from_slice(stripped);
+        } else {
+            self.push_tlv(Tag::INTEGER.0, stripped)?;
+        }
+        Ok(())
+    }
+
+    /// 이미 DER 인코딩된 INTEGER 바이트열을 그대로 기록하는 함수입니다.
+    ///
+    /// # Security Note
+    /// 호출자가 유효한 DER INTEGER 값 바이트를 제공해야 합니다.
+    pub fn write_integer_raw(&mut self, der_integer_value: &[u8]) -> Result<(), ArmorError> {
+        self.push_tlv(Tag::INTEGER.0, der_integer_value)
+    }
+
+    /// OCTET STRING을 인코딩하는 함수입니다.
+    pub fn write_octet_string(&mut self, data: &[u8]) -> Result<(), ArmorError> {
+        self.push_tlv(Tag::OCTET_STRING.0, data)
+    }
+
+    /// BIT STRING을 인코딩하는 함수입니다.
+    ///
+    /// # Arguments
+    /// - `data` — 비트 데이터 바이트열
+    /// - `unused_bits` — 마지막 바이트의 미사용 비트 수 (0-7)
+    ///
+    /// # Errors
+    /// `unused_bits > 7` 또는 `unused_bits > 0`이면서 `data`가 비어 있으면 `InvalidBitString`.
+    pub fn write_bit_string(&mut self, data: &[u8], unused_bits: u8) -> Result<(), ArmorError> {
+        if unused_bits > 7 {
+            return Err(DER(DerError::InvalidBitString));
+        }
+        if unused_bits > 0 && data.is_empty() {
+            return Err(DER(DerError::InvalidBitString));
+        }
+        let value_len = data
+            .len()
+            .checked_add(1)
+            .ok_or(DER(DerError::LengthOverflow))?;
+        self.buf.push(Tag::BIT_STRING.0);
+        length::encode_length(&mut self.buf, value_len)?;
+        self.buf.push(unused_bits);
+        self.buf.extend_from_slice(data);
+        Ok(())
+    }
+
+    /// OID를 인코딩하는 함수입니다.
+    pub fn write_oid(&mut self, oid: &Oid) -> Result<(), ArmorError> {
+        let arcs = oid.arcs();
+        if arcs.len() < 2 {
+            return Err(DER(DerError::InvalidOid));
+        }
+
+        // 값 바이트를 임시 버퍼에 인코딩
+        let mut value: Vec<u8> = Vec::new();
+
+        // 첫 번째 하위식별자: 40*a0 + a1
+        let first_sub = (arcs[0] as u64)
+            .checked_mul(40)
+            .and_then(|v| v.checked_add(arcs[1] as u64))
+            .ok_or(DER(DerError::InvalidOid))? as u32;
+        asn1::encode_base128(&mut value, first_sub);
+
+        for &arc in &arcs[2..] {
+            asn1::encode_base128(&mut value, arc);
+        }
+
+        self.push_tlv(Tag::OID.0, &value)
+    }
+
+    /// NULL을 인코딩하는 함수입니다.
+    pub fn write_null(&mut self) -> Result<(), ArmorError> {
+        self.buf.push(Tag::NULL.0);
+        self.buf.push(0x00);
+        Ok(())
+    }
+
+    /// BOOLEAN을 인코딩하는 함수입니다.
+    ///
+    /// # Security Note
+    /// DER 규칙: true는 0xFF, false는 0x00으로 인코딩합니다.
+    pub fn write_boolean(&mut self, value: bool) -> Result<(), ArmorError> {
+        self.buf.push(Tag::BOOLEAN.0);
+        self.buf.push(0x01);
+        self.buf.push(if value { 0xFF } else { 0x00 });
+        Ok(())
+    }
+
+    //
+    // 내부 헬퍼
+    //
+
+    fn push_tlv(&mut self, tag: u8, value: &[u8]) -> Result<(), ArmorError> {
+        self.buf.push(tag);
+        length::encode_length(&mut self.buf, value.len())?;
+        self.buf.extend_from_slice(value);
+        Ok(())
+    }
+}
+
+impl Default for DerWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 선행 0x00 바이트를 제거하되, 마지막 바이트는 보존합니다.
+fn strip_leading_zeros(bytes: &[u8]) -> &[u8] {
+    if bytes.is_empty() {
+        return bytes;
+    }
+    let first_nonzero = bytes
+        .iter()
+        .position(|&b| b != 0x00)
+        .unwrap_or(bytes.len() - 1);
+    &bytes[first_nonzero..]
+}

--- a/crypto/armor/src/error.rs
+++ b/crypto/armor/src/error.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArmorError {
+    ASN1(crate::asn1::ASN1Error),
+    DER(crate::der::DerError),
+}

--- a/crypto/armor/tests/der_test.rs
+++ b/crypto/armor/tests/der_test.rs
@@ -1,0 +1,454 @@
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use std::vec;
+    use entlib_native_armor::ArmorError::{ASN1, DER};
+    use entlib_native_armor::der::{DerError, DerReader, DerWriter, MAX_DEPTH};
+    use entlib_native_armor::asn1::{ASN1Error, Oid};
+
+    //
+    // 길이 인코딩
+    //
+
+    #[test]
+    fn length_short_form_roundtrip() {
+        let mut w = DerWriter::new();
+        w.write_null().unwrap();
+        // NULL = 05 00 (길이 0 → 단형식 0x00)
+        assert_eq!(w.finish(), &[0x05, 0x00]);
+    }
+
+    #[test]
+    fn length_long_form_roundtrip() {
+        // 길이 128짜리 OCTET STRING: 04 81 80 [128 bytes of 0xAB]
+        let data = vec![0xABu8; 128];
+        let mut w = DerWriter::new();
+        w.write_octet_string(&data).unwrap();
+        let encoded = w.finish();
+        assert_eq!(&encoded[..3], &[0x04, 0x81, 0x80]);
+
+        let mut r = DerReader::new(&encoded).unwrap();
+        let decoded = r.read_octet_string().unwrap();
+        assert_eq!(decoded, data.as_slice());
+        r.expect_empty().unwrap();
+    }
+
+    #[test]
+    fn reject_indefinite_length() {
+        // 0x30 0x80 ... (SEQUENCE with indefinite length)
+        let input = [0x30u8, 0x80, 0x00, 0x00];
+        let mut depth = MAX_DEPTH;
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_sequence(&mut depth).unwrap_err();
+        assert_eq!(err, DER(DerError::IndefiniteLength));
+    }
+
+    #[test]
+    fn reject_non_minimal_length() {
+        // 길이 1을 장형식(0x81 0x01)으로 표현 — DER 위반
+        let input = [0x04u8, 0x81, 0x01, 0xAA];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_octet_string().unwrap_err();
+        assert_eq!(err, DER(DerError::NonMinimalLength));
+    }
+
+    #[test]
+    fn reject_length_leading_zero() {
+        // 장형식 길이 앞에 0x00 (0x82 0x00 0x80)
+        let input = [0x04u8, 0x82, 0x00, 0x80];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_octet_string().unwrap_err();
+        assert_eq!(err, DER(DerError::NonMinimalLength));
+    }
+
+    //
+    // 태그 거부
+    //
+
+    #[test]
+    fn reject_long_form_tag() {
+        // 0x1F = 장형식 태그 시작 마커 → 거부
+        let input = [0x1Fu8, 0x01, 0x01, 0x00];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_tlv().unwrap_err();
+        assert_eq!(err, DER(DerError::InvalidTag));
+    }
+
+    #[test]
+    fn reject_eoc_tag() {
+        let input = [0x00u8, 0x00];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_tlv().unwrap_err();
+        assert_eq!(err, DER(DerError::InvalidTag));
+    }
+
+    //
+    // NULL
+    //
+
+    #[test]
+    fn null_roundtrip() {
+        let mut w = DerWriter::new();
+        w.write_null().unwrap();
+        let enc = w.finish();
+        assert_eq!(enc, &[0x05, 0x00]);
+
+        let mut r = DerReader::new(&enc).unwrap();
+        r.read_null().unwrap();
+        r.expect_empty().unwrap();
+    }
+
+    #[test]
+    fn reject_null_with_content() {
+        // NULL이 0 이외의 길이를 가지면 거부
+        let input = [0x05u8, 0x01, 0x00];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_null().unwrap_err();
+        assert_eq!(err, DER(DerError::InvalidLength));
+    }
+
+    //
+    // BOOLEAN
+    //
+
+    #[test]
+    fn boolean_roundtrip() {
+        for &val in &[true, false] {
+            let mut w = DerWriter::new();
+            w.write_boolean(val).unwrap();
+            let enc = w.finish();
+            let mut r = DerReader::new(&enc).unwrap();
+            assert_eq!(r.read_boolean().unwrap(), val);
+        }
+    }
+
+    #[test]
+    fn reject_ber_boolean() {
+        // BER true는 0x01이지만 DER에서는 0xFF만 허용
+        let input = [0x01u8, 0x01, 0x01];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_boolean().unwrap_err();
+        assert_eq!(err, DER(DerError::InvalidBooleanEncoding));
+    }
+
+    //
+    // INTEGER
+    //
+
+    #[test]
+    fn integer_zero_roundtrip() {
+        let mut w = DerWriter::new();
+        w.write_integer_unsigned(&[]).unwrap();
+        let enc = w.finish();
+        // INTEGER 0 = 02 01 00
+        assert_eq!(enc, &[0x02, 0x01, 0x00]);
+
+        let mut r = DerReader::new(&enc).unwrap();
+        let bytes = r.read_integer_bytes().unwrap();
+        assert_eq!(bytes, &[0x00]);
+    }
+
+    #[test]
+    fn integer_positive_with_high_bit() {
+        // 값 0x80 → 부호 바이트 필요: 02 02 00 80
+        let mut w = DerWriter::new();
+        w.write_integer_unsigned(&[0x80]).unwrap();
+        let enc = w.finish();
+        assert_eq!(enc, &[0x02, 0x02, 0x00, 0x80]);
+    }
+
+    #[test]
+    fn integer_strips_leading_zeros() {
+        // [0x00, 0x00, 0x01] → 값 1 → 02 01 01
+        let mut w = DerWriter::new();
+        w.write_integer_unsigned(&[0x00, 0x00, 0x01]).unwrap();
+        let enc = w.finish();
+        assert_eq!(enc, &[0x02, 0x01, 0x01]);
+    }
+
+    #[test]
+    fn reject_non_minimal_integer() {
+        // 02 03 00 00 01 → 선행 0x00 뒤의 바이트 MSB = 0 → 비최소
+        let input = [0x02u8, 0x03, 0x00, 0x00, 0x01];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_integer_bytes().unwrap_err();
+        assert_eq!(err, DER(DerError::NonMinimalInteger));
+    }
+
+    #[test]
+    fn reject_non_minimal_integer_neg() {
+        // 02 03 FF FF 80 → 선행 0xFF 뒤의 바이트 MSB = 1 → 비최소
+        let input = [0x02u8, 0x03, 0xFF, 0xFF, 0x80];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_integer_bytes().unwrap_err();
+        assert_eq!(err, DER(DerError::NonMinimalInteger));
+    }
+
+    //
+    // OCTET STRING
+    //
+
+    #[test]
+    fn octet_string_roundtrip() {
+        let data = b"hello DER";
+        let mut w = DerWriter::new();
+        w.write_octet_string(data).unwrap();
+        let enc = w.finish();
+
+        let mut r = DerReader::new(&enc).unwrap();
+        assert_eq!(r.read_octet_string().unwrap(), data);
+        r.expect_empty().unwrap();
+    }
+
+    //
+    // BIT STRING
+    //
+
+    #[test]
+    fn bit_string_roundtrip() {
+        let data = [0xDE, 0xAD, 0xBE, 0xEF];
+        let mut w = DerWriter::new();
+        w.write_bit_string(&data, 0).unwrap();
+        let enc = w.finish();
+
+        let mut r = DerReader::new(&enc).unwrap();
+        let (decoded, unused) = r.read_bit_string().unwrap();
+        assert_eq!(decoded, &data);
+        assert_eq!(unused, 0);
+    }
+
+    #[test]
+    fn reject_bit_string_invalid_unused_bits() {
+        // unused_bits = 8 → 범위 초과
+        let input = [0x03u8, 0x02, 0x08, 0x00];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_bit_string().unwrap_err();
+        assert_eq!(err, DER(DerError::InvalidBitString));
+    }
+
+    // OID
+
+    // ML-DSA-44: 2.16.840.1.101.3.4.3.17 (18: 65)
+    // ML-DSA-87: .....................19
+    // 수동 인코딩 (44) >>>
+    //   first_sub = 40*2+16 = 96 = 0x60 → [0x60]
+    //   840 = 6*128+72 → [0x86, 0x48]
+    //   1   → [0x01]
+    //   101 → [0x65]
+    //   3   → [0x03]
+    //   4   → [0x04]
+    //   3   → [0x03]
+    //   17  → [0x11]
+    // 값 바이트: 60 86 48 01 65 03 04 03 11 (9 bytes)
+    // TLV: 06 09 60 86 48 01 65 03 04 03 11
+    const MLDSA44_DER: [u8; 11] = [
+        0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11,
+        // 바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?
+        //바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?바이트 맞는데?
+    ];
+
+    #[test]
+    fn oid_decode_mldsa44() {
+        let expected = Oid::from_arcs(&[2, 16, 840, 1, 101, 3, 4, 3, 17]).unwrap();
+        let mut r = DerReader::new(&MLDSA44_DER).unwrap();
+        let oid = r.read_oid().unwrap();
+        assert!(oid.ct_eq(&expected));
+    }
+
+    #[test]
+    fn oid_encode_mldsa44() {
+        let oid = Oid::from_arcs(&[2, 16, 840, 1, 101, 3, 4, 3, 17]).unwrap();
+        let mut w = DerWriter::new();
+        w.write_oid(&oid).unwrap();
+        assert_eq!(w.finish().as_slice(), &MLDSA44_DER);
+    }
+
+    #[test]
+    fn oid_ct_eq_distinguishes_different_oids() {
+        let a = Oid::from_arcs(&[2, 16, 840, 1, 101, 3, 4, 3, 17]).unwrap();
+        let b = Oid::from_arcs(&[2, 16, 840, 1, 101, 3, 4, 3, 18]).unwrap(); // 65
+        assert!(!a.ct_eq(&b));
+    }
+
+    #[test]
+    fn oid_reject_invalid_first_arc() {
+        let err = Oid::from_arcs(&[3, 0]).unwrap_err();
+        assert_eq!(err, ASN1(ASN1Error::InvalidOid));
+    }
+
+    #[test]
+    fn oid_reject_second_arc_out_of_range() {
+        // 첫 아크 0이면 두 번째는 0–39
+        let err = Oid::from_arcs(&[0, 40]).unwrap_err();
+        assert_eq!(err, ASN1(ASN1Error::InvalidOid));
+    }
+
+    #[test]
+    fn oid_roundtrip_rsaencryption() {
+        // rsaEncryption: 1.2.840.113549.1.1.1
+        let oid = Oid::from_arcs(&[1, 2, 840, 113549, 1, 1, 1]).unwrap();
+        let mut w = DerWriter::new();
+        w.write_oid(&oid).unwrap();
+        let enc = w.finish();
+
+        let mut r = DerReader::new(&enc).unwrap();
+        let decoded = r.read_oid().unwrap();
+        assert!(decoded.ct_eq(&oid));
+    }
+
+    //
+    // SEQUENCE
+    //
+
+    #[test]
+    fn sequence_roundtrip() {
+        let oid = Oid::from_arcs(&[2, 16, 840, 1, 101, 3, 4, 3, 17]).unwrap();
+        let data = b"test payload";
+
+        let mut inner = DerWriter::new();
+        inner.write_oid(&oid).unwrap();
+        inner.write_octet_string(data).unwrap();
+
+        let mut outer = DerWriter::new();
+        outer.write_sequence(&inner.finish()).unwrap();
+        let enc = outer.finish();
+
+        let mut depth = MAX_DEPTH;
+        let mut r = DerReader::new(&enc).unwrap();
+        let mut seq = r.read_sequence(&mut depth).unwrap();
+        let decoded_oid = seq.read_oid().unwrap();
+        let decoded_data = seq.read_octet_string().unwrap();
+        seq.expect_empty().unwrap();
+        r.expect_empty().unwrap();
+
+        assert!(decoded_oid.ct_eq(&oid));
+        assert_eq!(decoded_data, data);
+    }
+
+    #[test]
+    fn nested_sequence_depth_tracking() {
+        // SEQUENCE { SEQUENCE { NULL } } — 깊이 2 소비
+        let mut level2 = DerWriter::new();
+        level2.write_null().unwrap();
+
+        let mut level1 = DerWriter::new();
+        level1.write_sequence(&level2.finish()).unwrap();
+
+        let mut outer = DerWriter::new();
+        outer.write_sequence(&level1.finish()).unwrap();
+        let enc = outer.finish();
+
+        let mut depth = MAX_DEPTH;
+        let mut r = DerReader::new(&enc).unwrap();
+        let mut s1 = r.read_sequence(&mut depth).unwrap();
+        assert_eq!(depth, MAX_DEPTH - 1);
+        let mut s2 = s1.read_sequence(&mut depth).unwrap();
+        assert_eq!(depth, MAX_DEPTH - 2);
+        s2.read_null().unwrap();
+        s2.expect_empty().unwrap();
+        s1.expect_empty().unwrap();
+        r.expect_empty().unwrap();
+    }
+
+    #[test]
+    fn reject_excessive_depth() {
+        // 최대 깊이 초과 시도
+        let mut inner = DerWriter::new();
+        inner.write_null().unwrap();
+        let mut outer = DerWriter::new();
+        outer.write_sequence(&inner.finish()).unwrap();
+        let enc = outer.finish();
+
+        // depth = 0으로 강제 설정
+        let mut depth = 0u8;
+        let mut r = DerReader::new(&enc).unwrap();
+        let err = r.read_sequence(&mut depth).unwrap_err();
+        assert_eq!(err, DER(DerError::MaxDepthExceeded));
+    }
+
+    //
+    // 버퍼 오버리드 방어
+    //
+
+    #[test]
+    fn reject_truncated_tlv() {
+        // 길이 16이라고 주장하지만 실제 데이터 1바이트만 있음
+        let input = [0x04u8, 0x10, 0xAA];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_octet_string().unwrap_err();
+        assert_eq!(err, DER(DerError::UnexpectedEof));
+    }
+
+    #[test]
+    fn reject_truncated_length() {
+        // 장형식 길이를 주장하지만 길이 바이트가 없음 (0x81 후 EOF)
+        let input = [0x04u8, 0x81];
+        let mut r = DerReader::new(&input).unwrap();
+        let err = r.read_octet_string().unwrap_err();
+        assert_eq!(err, DER(DerError::UnexpectedEof));
+    }
+
+    #[test]
+    fn reject_trailing_data() {
+        let mut w = DerWriter::new();
+        w.write_null().unwrap();
+        let mut enc = w.finish();
+        enc.push(0x00); // 잔여 바이트 추가
+
+        let mut r = DerReader::new(&enc).unwrap();
+        r.read_null().unwrap();
+        let err = r.expect_empty().unwrap_err();
+        assert_eq!(err, DER(DerError::TrailingData));
+    }
+
+    //
+    // EXPLICIT / IMPLICIT 컨텍스트 태그
+    //
+
+    #[test]
+    fn explicit_tag_roundtrip() {
+        let data = b"wrapped";
+        let mut inner = DerWriter::new();
+        inner.write_octet_string(data).unwrap();
+
+        let mut w = DerWriter::new();
+        w.write_explicit_tag(0, &inner.finish()).unwrap();
+        let enc = w.finish();
+
+        let mut depth = MAX_DEPTH;
+        let mut r = DerReader::new(&enc).unwrap();
+        let mut tagged = r.read_explicit_tag(0, &mut depth).unwrap();
+        assert_eq!(tagged.read_octet_string().unwrap(), data);
+        tagged.expect_empty().unwrap();
+        r.expect_empty().unwrap();
+    }
+
+    #[test]
+    fn implicit_tag_roundtrip() {
+        let data = b"implicit";
+        let mut w = DerWriter::new();
+        w.write_implicit_tag(1, data).unwrap();
+        let enc = w.finish();
+
+        let mut r = DerReader::new(&enc).unwrap();
+        let value = r.read_implicit_value(1).unwrap();
+        assert_eq!(value, data);
+        r.expect_empty().unwrap();
+    }
+
+    //
+    // SecureBuffer
+    //
+
+    #[test]
+    fn integer_secure_roundtrip() {
+        let key_bytes = [0x01u8, 0x23, 0x45, 0x67];
+        let mut w = DerWriter::new();
+        w.write_integer_unsigned(&key_bytes).unwrap();
+        let enc = w.finish();
+
+        let mut r = DerReader::new(&enc).unwrap();
+        let secure = r.read_integer_secure().unwrap();
+        assert_eq!(secure.as_slice(), &key_bytes);
+    }
+}


### PR DESCRIPTION
- [X] ASN.1 (OID / Tagging)
- [X] DER
- [x] PEM
- [x] I/O
- [ ] 테스트
- [ ] crypto/armor 통합 명세

ASN.1 인/디코더는 필요한 부분만 구현 예정(너무 방대해서 나중에).